### PR TITLE
Dns Caching + Docker infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.4.1-alpine
 
-RUN apk update && apk add bind-tools bash python git
+RUN apk update && apk add bind-tools bash python3 git
 
 ADD . /code 
 VOLUME /code/code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22.4.1-alpine
+
+RUN apk update && apk add bind-tools bash python git
+
+ADD . /code 
+VOLUME /code/code
+
+
+ENTRYPOINT /code/config/wrap.sh

--- a/config/Corefile
+++ b/config/Corefile
@@ -1,0 +1,4 @@
+. {
+	forward . tls://1.1.1.1
+	cache
+}

--- a/config/wrap.sh
+++ b/config/wrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "nameserver $(dig +short dns)" > /etc/resolv.conf
+
+/bin/sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+services: 
+  dns: 
+    image: coredns/coredns
+    volumes:
+      - ./config:/config
+    command: -conf /config/Corefile
+  nodejs:
+    build: .
+    volumes:
+      - ./:/code
+    links:
+      - "dns"
+
+
+


### PR DESCRIPTION
This PR adds DNS caching through a dedicated CoreDNS service inside a Docker container.
The analysis can be executed through `docker-compose run nodejs COMMAND`  this repository is volume mapped to `/code` in the container itself.